### PR TITLE
Allow irregular spaces before 'required' text

### DIFF
--- a/find.go
+++ b/find.go
@@ -129,18 +129,23 @@ func (f *finder) structType(name *ast.Ident, t *ast.StructType) {
 	}
 }
 
-const _required = "// required"
+const _required = "required"
 
 func isRequiredComment(c *ast.Comment) bool {
-	if c.Text == _required {
-		return true
-	}
-
-	if !strings.HasPrefix(c.Text, _required) {
+	text, ok := strings.CutPrefix(c.Text, "//")
+	if !ok {
+		// This is a '/*' comment which we do not support.
 		return false
 	}
+	text = strings.TrimSpace(text)
 
-	for _, r := range c.Text[len(_required):] {
+	if text == _required {
+		return true
+	}
+	if !strings.HasPrefix(text, _required) {
+		return false
+	}
+	for _, r := range text[len(_required):] {
 		return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
 	}
 

--- a/testdata/src/d/d.go
+++ b/testdata/src/d/d.go
@@ -32,3 +32,25 @@ type Handler struct { // want Handler:"required<Callback>"
 func _() {
 	fmt.Println(Handler{}) // want "missing required fields: Callback"
 }
+
+type irregularSpacing struct { // want irregularSpacing:"required<A, B, C, D, E>"
+	A int //required
+	B int //  required
+	C int //     required
+	D int //required: some context
+	E int //   required: some context
+}
+
+func _() {
+	fmt.Println(irregularSpacing{}) // want "missing required fields: A, B, C, D, E"
+}
+
+type invalidTags struct { // want invalidTags:"required<A>"
+	A int // required
+	B int // requiredsuffix
+	C int // prefixrequired
+}
+
+func _() {
+	fmt.Println(invalidTags{}) // want "missing required fields: A"
+}

--- a/testdata/src/d/d.go
+++ b/testdata/src/d/d.go
@@ -34,11 +34,12 @@ func _() {
 }
 
 type irregularSpacing struct { // want irregularSpacing:"required<A, B, C, D, E>"
-	A int //required
+	A int // required
 	B int //  required
 	C int //     required
-	D int //required: some context
+	D int // required: some context
 	E int //   required: some context
+	F int /* required: not enforced */
 }
 
 func _() {


### PR DESCRIPTION
Today, requiredfield does not detect annotations which have irregular
spacing before the `required` text, e.g. it will not validate the following:
```
//required (no space)
//   required (more than one space)
```
`gofmt` won't stop people from writing comments like this, so requiredfield
should be permissive and treat these as valid `required` tags.