### PR TITLE
fix: Don't report missing fields for unkeyed struct literals

### DIFF
--- a/.changes/unreleased/Fixed-20250511-112052.yaml
+++ b/.changes/unreleased/Fixed-20250511-112052.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix incorrectly reporting missing fields for unkeyed struct literals.
+time: 2025-05-11T11:20:52.55766-07:00

--- a/enforce.go
+++ b/enforce.go
@@ -69,7 +69,14 @@ func (e *enforcer) Enforce(inspect *inspector.Inspector) {
 		for _, elt := range lit.Elts {
 			kv, ok := elt.(*ast.KeyValueExpr)
 			if !ok {
-				continue
+				// Elements will not be KeyValueExprs
+				// only if unkeyed struct literal is used.
+				// In case of unkeyed literals,
+				// the compiler enforces that
+				// all fields are specified,
+				// so there's nothing for us to do
+				// for this struct.
+				return
 			}
 			id, ok := kv.Key.(*ast.Ident)
 			if !ok {

--- a/testdata/src/a/a.go
+++ b/testdata/src/a/a.go
@@ -67,4 +67,8 @@ func x() {
 
 	// Aliased.
 	fmt.Println(aliasedStruct{}) // want "missing required fields: A, B"
+
+	// Unkeyed struct literals.
+	fmt.Println(RequiredExported{}) // want "missing required fields: A, B"
+	fmt.Println(RequiredExported{"a", 1})
 }


### PR DESCRIPTION
For `Foo{bar, baz}`, the compiler enforces that all fields are listed
so there's nothing for requiredfield to do in that case.

Resolves #46