### PR TITLE
Don't enforce inside returns with non-nil errors

### DIFF
--- a/.changes/unreleased/Changed-20250511-145922.yaml
+++ b/.changes/unreleased/Changed-20250511-145922.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Don't enforce required fields if the struct is part of a return statement with a non-nil error.
+time: 2025-05-11T14:59:22.293016-07:00

--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ u := User{
 u.Name = name
 ```
 
+This behavior is not enforced if the struct is being initialized
+as part of a return statement with a (probably) non-nil error value:
+
+```go
+if err != nil {
+    return User{}, err // ok, because the error is non-nil
+}
+```
+
 ## FAQ
 
 ### Why a comment instead of a struct tag?

--- a/doc/behavior.md
+++ b/doc/behavior.md
@@ -21,3 +21,12 @@ u := User{
 // ...
 u.Name = name
 ```
+
+This behavior is not enforced if the struct is being initialized
+as part of a return statement with a (probably) non-nil error value:
+
+```go
+if err != nil {
+    return User{}, err // ok, because the error is non-nil
+}
+```

--- a/enforce.go
+++ b/enforce.go
@@ -23,78 +23,180 @@ var _enforceNodeFilter = []ast.Node{
 }
 
 func (e *enforcer) Enforce(inspect *inspector.Inspector) {
-	inspect.Preorder(_enforceNodeFilter, func(n ast.Node) {
-		lit := n.(*ast.CompositeLit)
-		typ := e.Info.TypeOf(lit)
-
-		if ptr, ok := typ.(*types.Pointer); ok {
-			typ = ptr.Elem()
-		}
-		if alias, ok := typ.(*types.Alias); ok {
-			typ = types.Unalias(alias)
+	inspect.WithStack(_enforceNodeFilter, func(n ast.Node, push bool, stack []ast.Node) (proceed bool) {
+		if !push {
+			return true
 		}
 
-		var unset map[string]struct{}
-		switch typ := typ.(type) {
-		case *types.Named:
-			// named struct (probably)
-			var reqFields hasRequiredFields
-			if !e.ImportObjectFact(typ.Obj(), &reqFields) {
-				return
-			}
-
-			unset = make(map[string]struct{}, len(reqFields.List))
-			for _, name := range reqFields.List {
-				unset[name] = struct{}{}
-			}
-		case *types.Struct:
-			// anonymous struct
-			var fact isRequiredField
-			for i := 0; i < typ.NumFields(); i++ {
-				f := typ.Field(i)
-				if e.ImportObjectFact(f, &fact) {
-					if unset == nil {
-						unset = make(map[string]struct{})
-					}
-					unset[f.Name()] = struct{}{}
-				}
-			}
-		}
-
-		if len(unset) == 0 {
-			return
-		}
-
-		// Check that all required fields are set.
-		for _, elt := range lit.Elts {
-			kv, ok := elt.(*ast.KeyValueExpr)
-			if !ok {
-				// Elements will not be KeyValueExprs
-				// only if unkeyed struct literal is used.
-				// In case of unkeyed literals,
-				// the compiler enforces that
-				// all fields are specified,
-				// so there's nothing for us to do
-				// for this struct.
-				return
-			}
-			id, ok := kv.Key.(*ast.Ident)
-			if !ok {
-				continue
-			}
-			delete(unset, id.Name)
-		}
-
-		if len(unset) == 0 {
-			return
-		}
-
-		var missing []string
-		for f := range unset {
-			missing = append(missing, f)
-		}
-		sort.Strings(missing)
-
-		e.Reportf(lit.Lbrace, "missing required fields: %s", strings.Join(missing, ", "))
+		e.visit(n, stack)
+		return true
 	})
+}
+
+func (e *enforcer) visit(n ast.Node, stack []ast.Node) {
+	lit := n.(*ast.CompositeLit)
+	typ := e.Info.TypeOf(lit)
+
+	if ptr, ok := typ.(*types.Pointer); ok {
+		typ = ptr.Elem()
+	}
+	if alias, ok := typ.(*types.Alias); ok {
+		typ = types.Unalias(alias)
+	}
+
+	var unset map[string]struct{} // required fields that are not set
+	switch typ := typ.(type) {
+	case *types.Named:
+		// named struct (probably)
+		var reqFields hasRequiredFields
+		if !e.ImportObjectFact(typ.Obj(), &reqFields) {
+			return
+		}
+
+		unset = make(map[string]struct{}, len(reqFields.List))
+		for _, name := range reqFields.List {
+			unset[name] = struct{}{}
+		}
+	case *types.Struct:
+		// anonymous struct
+		var fact isRequiredField
+		for i := 0; i < typ.NumFields(); i++ {
+			f := typ.Field(i)
+			if e.ImportObjectFact(f, &fact) {
+				if unset == nil {
+					unset = make(map[string]struct{})
+				}
+				unset[f.Name()] = struct{}{}
+			}
+		}
+	}
+
+	if len(unset) == 0 {
+		// Type has no required fields, or is not a struct.
+		return
+	}
+
+	// If a function returns a struct and an error,
+	// it's common to do 'return MyStruct{}, err' for failures.
+	// It's not desirable to enforce required fields in this case.
+	//
+	// Therefore, if we encounter a struct literal in a return,
+	// and the last value of that return statement is an error
+	// that is not explicitly set to "nil",
+	// we will not enforce required fields on that struct literal.
+	if len(stack) > 1 && e.isReturnedWithNonNilError(stack) {
+		// The struct literal is part of a return statement
+		// that has a non-nil error as its last return value.
+		return
+	}
+
+	// Check that all required fields are set.
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			// Elements will not be KeyValueExprs
+			// only if unkeyed struct literal is used.
+			// In case of unkeyed literals,
+			// the compiler enforces that
+			// all fields are specified,
+			// so there's nothing for us to do
+			// for this struct.
+			return
+		}
+		id, ok := kv.Key.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		delete(unset, id.Name)
+	}
+
+	if len(unset) == 0 {
+		return
+	}
+
+	var missing []string
+	for f := range unset {
+		missing = append(missing, f)
+	}
+	sort.Strings(missing)
+
+	e.Reportf(lit.Lbrace, "missing required fields: %s", strings.Join(missing, ", "))
+}
+
+// isReturnedWithNonNilError reports whether target is part of a return
+// statement that has a non-nil error as its last return value,
+// but is not itself the last return value or a subexpression of it.
+//
+// The "but" is important:
+// if the target is the last return value (or part of it),
+// it should still be checked for required fields, e.g.
+//
+//	return nil, &MyError{...} // and MyError has required fields
+func (e *enforcer) isReturnedWithNonNilError(stack []ast.Node) bool {
+	// Find the nearest return statement.
+	var retStmt *ast.ReturnStmt
+	retIdx := -1
+	for idx := len(stack) - 1; idx >= 0; idx-- {
+		var ok bool
+		if retStmt, ok = stack[idx].(*ast.ReturnStmt); ok {
+			retIdx = idx
+			break
+		}
+	}
+	if retIdx == -1 {
+		// No return statement found.
+		return false
+	}
+
+	// Find the nearest function's type for the return statement.
+	var ftype *ast.FuncType
+	for idx := retIdx - 1; idx >= 0; idx-- {
+		switch n := stack[idx].(type) {
+		case *ast.FuncDecl:
+			ftype = n.Type
+		case *ast.FuncLit:
+			ftype = n.Type
+		}
+	}
+	if ftype == nil {
+		// Impossible, but we don't want to panic.
+		return false
+	}
+
+	// The last return type must be an error.
+	returnTypes := ftype.Results.List
+	if len(returnTypes) == 0 {
+		// No return types.
+		return false
+	}
+	lastReturnType, ok := returnTypes[len(returnTypes)-1].Type.(*ast.Ident)
+	if !ok || lastReturnType.Name != "error" {
+		// The last return type is not "error".
+		return false
+	}
+
+	// If last return value is nil, we want to enforce required fields.
+	lastReturn := retStmt.Results[len(retStmt.Results)-1]
+	if id, ok := lastReturn.(*ast.Ident); ok && id.Name == "nil" {
+		return false
+	}
+
+	// At this point, we know this is a return statement in a function
+	// where the last return type is an error,
+	// and the value is definitely not the nil identifier.
+	//
+	// We want to ignore this node (return true) only if
+	// the target is not part of the last return value itself.
+	//
+	// To do this, we'll verify that lastReturn is not equal to,
+	// or an ancestor of the target. (stack[len(stack)-1] is target)
+	for idx := len(stack) - 1; idx > retIdx; idx-- {
+		if stack[idx] == lastReturn {
+			// Target is part of the last return value.
+			return false
+		}
+	}
+
+	// Target is not part of the last return value.
+	return true
 }

--- a/find.go
+++ b/find.go
@@ -16,8 +16,8 @@ type finder struct {
 	Fset *token.FileSet // required
 	Info *types.Info    // required
 
-	ExportObjectFact func(obj types.Object, fact analysis.Fact)           // required
-	Reportf          func(pos token.Pos, msg string, args ...interface{}) // required
+	ExportObjectFact func(obj types.Object, fact analysis.Fact)   // required
+	Reportf          func(pos token.Pos, msg string, args ...any) // required
 }
 
 var _finderNodeFilter = []ast.Node{

--- a/testdata/src/e/e.go
+++ b/testdata/src/e/e.go
@@ -1,0 +1,78 @@
+package e
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+)
+
+type Foo struct { // want Foo:"required<Bar>"
+	Bar int // required
+	Baz string
+}
+
+type MyError struct { // want MyError:"required<Msg>"
+	Msg string // required
+}
+
+func (e *MyError) Error() string { return e.Msg }
+
+var errSadness = errors.New("great sadness")
+
+func noReturnValue() {
+	if rand.Int()%2 == 0 {
+		return // ok
+	}
+	fmt.Println(Foo{}) // want "missing required fields: Bar"
+}
+
+func nonNilError() (Foo, error) {
+	if rand.Int()%2 == 0 {
+		return Foo{}, errors.New("fail") // ok
+	} else {
+		return Foo{}, errSadness // ok
+	}
+}
+
+func nilError() (Foo, error) {
+	if rand.Int()%2 == 0 {
+		return Foo{Bar: 42}, nil // ok
+	} else {
+		return Foo{}, nil // want "missing required fields: Bar"
+	}
+}
+
+func errorObject() (Foo, error) {
+	if rand.Int()%2 == 0 {
+		return Foo{}, &MyError{Msg: "great sadness"} // ok
+	} else {
+		return Foo{}, &MyError{} // want "missing required fields: Msg"
+	}
+}
+
+var functionLiteral = func() (Foo, error) {
+	if rand.Int()%2 == 0 {
+		return Foo{}, &MyError{Msg: "great sadness"} // ok
+	} else {
+		return Foo{}, &MyError{} // want "missing required fields: Msg"
+	}
+}
+
+func errorIsNotLastReturn() (error, Foo) {
+	if rand.Int()%2 == 0 {
+		return errors.New("fail"), Foo{} // want "missing required fields: Bar"
+	} else {
+		return nil, Foo{} // want "missing required fields: Bar"
+	}
+}
+
+func errorObjectSubexpression() (Foo, error) {
+	switch rand.Int() % 3 {
+	case 0:
+		return Foo{}, &MyError{Msg: "great sadness"} // ok
+	case 1:
+		return Foo{}, fmt.Errorf("%w", &MyError{}) // want "missing required fields: Msg"
+	default:
+		return Foo{}, fmt.Errorf("%w", &MyError{Msg: "great sadness"}) // ok
+	}
+}


### PR DESCRIPTION
If a function has a struct return type alongside an error,
it's pretty standard to do this:

    if err != nil {
        return MyStruct{}, fmt.Errorf("do thing: %w", err)
    }

There's no reason to enforce required fields on the struct
because the contract is that the struct value is to be ignored
if the error is non-nil.

This change adds support to detect these cases and ignore them.
It is a bit messier than "ignore if part of return with non-nil error"
because we still want to enforce required fields if the non-nil error
itself is the thing with required fields, e.g.

    return nil, &MyError{...} // and MyError has required fields

Resolves #37