### PR TITLE
Fix function type resolution with nested funcs

### DIFF
--- a/.changes/unreleased/Fixed-20250811-163138.yaml
+++ b/.changes/unreleased/Fixed-20250811-163138.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Fix panic when returning a struct from a nested function literal.
+time: 2025-08-11T16:31:38.812525-07:00

--- a/enforce.go
+++ b/enforce.go
@@ -156,11 +156,11 @@ func (e *enforcer) isReturnedWithNonNilError(stack []ast.Node) bool {
 	}
 
 	// The last return type must be an error.
-	returnTypes := ftype.Results.List
-	if len(returnTypes) == 0 {
+	if ftype.Results == nil || len(ftype.Results.List) == 0 {
 		// No return types.
 		return false
 	}
+	returnTypes := ftype.Results.List
 	lastReturnType, ok := returnTypes[len(returnTypes)-1].Type.(*ast.Ident)
 	if !ok || lastReturnType.Name != "error" {
 		// The last return type is not "error".

--- a/enforce.go
+++ b/enforce.go
@@ -149,16 +149,8 @@ func (e *enforcer) isReturnedWithNonNilError(stack []ast.Node) bool {
 	}
 
 	// Find the nearest function's type for the return statement.
-	var ftype *ast.FuncType
-	for idx := retIdx - 1; idx >= 0; idx-- {
-		switch n := stack[idx].(type) {
-		case *ast.FuncDecl:
-			ftype = n.Type
-		case *ast.FuncLit:
-			ftype = n.Type
-		}
-	}
-	if ftype == nil {
+	ftype, ok := parentFuncType(stack[:retIdx])
+	if !ok || ftype == nil {
 		// Impossible, but we don't want to panic.
 		return false
 	}
@@ -199,4 +191,17 @@ func (e *enforcer) isReturnedWithNonNilError(stack []ast.Node) bool {
 
 	// Target is not part of the last return value.
 	return true
+}
+
+func parentFuncType(stack []ast.Node) (*ast.FuncType, bool) {
+	for idx := len(stack) - 1; idx >= 0; idx-- {
+		switch n := stack[idx].(type) {
+		case *ast.FuncDecl:
+			return n.Type, true
+		case *ast.FuncLit:
+			return n.Type, true
+		}
+	}
+
+	return nil, false
 }

--- a/testdata/src/e/e.go
+++ b/testdata/src/e/e.go
@@ -58,6 +58,12 @@ var functionLiteral = func() (Foo, error) {
 	}
 }
 
+func nestedFunctionLiteral() {
+	_ = func() Foo {
+		return Foo{} // want "missing required fields: Bar"
+	}
+}
+
 func errorIsNotLastReturn() (error, Foo) {
 	if rand.Int()%2 == 0 {
 		return errors.New("fail"), Foo{} // want "missing required fields: Bar"


### PR DESCRIPTION
Fixes #57

isReturnedWithNonNilError walks up from the return statement to find the matching function type, but it doesn't `break` when it finds the closest function type, which can lead to it using the wrong signature.

Move the function matching into a separate function to avoid a label on the loop so we can `break` correctly.